### PR TITLE
Adapt for upcoming release of new INSPIRE version

### DIFF
--- a/DumbOperation.m
+++ b/DumbOperation.m
@@ -49,7 +49,7 @@ static NSOperationQueue*_Aqueue=nil;
 +(NSOperationQueue*)spiresQueue;
 {
     if(!_Squeue){
-	_Squeue=[[NetworkOperationQueue alloc] initWithHost:@"inspirehep.net" andWaitBetweenOperations:
+	_Squeue=[[NetworkOperationQueue alloc] initWithHost:@"old.inspirehep.net" andWaitBetweenOperations:
                  [[NSUserDefaults standardUserDefaults] integerForKey:@"inspireWaitInSeconds"]];
 	[_Squeue setMaxConcurrentOperationCount:1];
     }

--- a/Info.plist
+++ b/Info.plist
@@ -100,7 +100,7 @@
 				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
-			<key>inspirehep.net</key>
+			<key>old.inspirehep.net</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>

--- a/SpiresHelper.m
+++ b/SpiresHelper.m
@@ -474,9 +474,9 @@ SpiresHelper*_sharedSpiresHelper=nil;
 {
     NSString*s;
     if(of){
-        s=[NSString stringWithFormat:@"http://inspirehep.net/search?p=%@&of=%@",search, of ];
+        s=[NSString stringWithFormat:@"http://old.inspirehep.net/search?p=%@&of=%@",search, of ];
     }else{
-        s=[NSString stringWithFormat:@"http://inspirehep.net/search?p=%@", search ];
+        s=[NSString stringWithFormat:@"http://old.inspirehep.net/search?p=%@", search ];
     }
     NSString*t=[s stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
     NSURL* url=[NSURL URLWithString:t];

--- a/inspire/Info.plist
+++ b/inspire/Info.plist
@@ -70,7 +70,7 @@
 				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
-			<key>inspirehep.net</key>
+			<key>old.inspirehep.net</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>


### PR DESCRIPTION
We will release the new INSPIRE version (currently at
https://labs.inspirehep.net) as the main website on Monday. The old
website will remain available at https://old.inspirehep.net for a couple
of months. The new API is not 100% ready for public use, so this commit
simply switches to the URL of the old website instead of using the new
one.

I know nothing about OS X application development, I did a stupid
search&replace, so there might be mistakes.